### PR TITLE
Accept single trigger in JSRule

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -2,7 +2,7 @@
 /**
  * Rules namespace.
  * This namespace allows creation of Openhab rules.
- * 
+ *
  * @namespace rules
  */
 
@@ -21,7 +21,7 @@ let factory = require('@runtime/rules').factory;
 
 /**
  * Generates an item name given it's configuration.
- * 
+ *
  * @memberOf rules
  * @private
  * @param {Object} ruleConfig The rule config
@@ -33,7 +33,7 @@ const itemNameForRule = function (ruleConfig) {
 
 /**
  * Links an item to a rule. When the item is switched on or off, so will the rule be.
- * 
+ *
  * @memberOf rules
  * @private
  * @param {HostRule} rule The rule to link to the item.
@@ -61,7 +61,7 @@ const linkItemToRule = function (rule, item) {
 
 /**
  * Gets the groups that an rule-toggling-item should be a member of. Will create the group item if necessary.
- * 
+ *
  * @memberOf rules
  * @private
  * @param {Object} ruleConfig The rule config describing the rule
@@ -81,23 +81,23 @@ const getGroupsForItem = function (ruleConfig) {
 
 /**
  * Creates a rule. The rule will be created and immediately available.
- * 
+ *
  * @example
  * import { rules, triggers } = require('ohj');
- * 
+ *
  * rules.JSRule({
  *  name: "my_new_rule",
  *  description": "this rule swizzles the swallows",
  *  triggers: triggers.GenericCronTrigger("0 30 16 * * ? *"),
  *  execute: triggerConfig => { //do stuff }
  * });
- * 
+ *
  * @memberOf rules
  * @param {Object} ruleConfig The rule config describing the rule
  * @param {String} ruleConfig.name the name of the rule
  * @param {String} ruleConfig.description a description of the rule
  * @param {*} ruleConfig.execute callback that will be called when the rule fires
- * @param {HostTrigger[]} ruleConfig.triggers triggers which will define when to fire the rule
+ * @param {HostTrigger|HostTrigger[]} ruleConfig.triggers triggers which will define when to fire the rule
  * @returns {HostRule} the created rule
  */
 let JSRule = function (ruleConfig) {
@@ -116,12 +116,15 @@ let JSRule = function (ruleConfig) {
         }
     };
 
-    var rule = new SimpleRule({
+    let rule = new SimpleRule({
         execute: doExecute,
         getUID: () => ruid
     });
 
-    var triggers = ruleConfig.triggers ? ruleConfig.triggers : ruleConfig.getEventTrigger();
+    let triggers = ruleConfig.triggers ? ruleConfig.triggers : ruleConfig.getEventTrigger();
+    if (!Array.isArray(triggers)) {
+        triggers = [triggers];
+    }
 
     rule.setTemplateUID(ruTemplateid);
 
@@ -182,7 +185,7 @@ let registerRule = function(rule) {
 /**
  * Creates a rule, with an associated SwitchItem that can be used to toggle the rule's enabled state.
  * The rule will be created and immediately available.
- * 
+ *
  * @memberOf rules
  * @param {Object} ruleConfig The rule config describing the rule
  * @param {String} ruleConfig.name the name of the rule
@@ -306,4 +309,3 @@ module.exports = {
     JSRule,
     SwitchableJSRule
 }
- 


### PR DESCRIPTION
The code block example suggests passing a single trigger instance is possible (see https://github.com/jpg0/ohj/blob/master/rules.js#L91), but it had to be an array actually. This change now accepts both. I believe that's reasonable, as many rules will have just a single trigger (e.g. cron), so having to wrap in an array explicitly might be annoying.